### PR TITLE
Make settings global

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -1,5 +1,9 @@
 Changes:
 
+Version 1.20, 2025-01-18
+- Windows 11: animated switch to new desktop is now optional
+- Improve commandline parsing
+
 Version 1.19, 2024-09-01
 - faster API call FindWindow instead of EnumWindows
 - Windows 11: animated switch to new desktop

--- a/Compile.bat
+++ b/Compile.bat
@@ -1,5 +1,5 @@
 @echo off
-:: Markus Scholtes, 2024
+:: Markus Scholtes, Duncan Lilly - 2024-2025
 :: Compile VirtualDesktop in .Net 4.x environment
 setlocal
 

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -1,13 +1,13 @@
-https://github.com/MScholtes/VirtualDesktop/
+https://github.com/DuncanL/VirtualDesktop/
 
 
 VirtualDesktop
 
 C# command line tool to manage virtual desktops in Windows 10 and Windows 11
 
-Version 1.19, 2024-09-01
-- faster API call FindWindow instead of EnumWindows
-- Windows 11: animated switch to new desktop
+Version 1.20, 2025-01-18
+- Windows 11: animated switch to new desktop is now optional
+- Improve commandline parsing
 
 (look for a powershell version here:
 https://github.com/MScholtes/PSVirtualDesktop
@@ -29,7 +29,7 @@ Generate:
 Description:
  Command line tool to manage the virtual desktops of Windows 10 and 11.
  Parameters can be given as a sequence of commands. The result - most of
- thetimes the number of the processed desktop - can be used as input for the
+ the times the number of the processed desktop - can be used as input for the
  next parameter. The result of the last command is returned as error level.
  Virtual desktop numbers start with 0.
 

--- a/VirtualDesktop.cs
+++ b/VirtualDesktop.cs
@@ -1,5 +1,5 @@
-// Author: Markus Scholtes, 2024
-// Version 1.19, 2024-09-01
+// Author: Markus Scholtes, Duncan Lilly - 2024-2025
+// Version 1.20 2025-01-18
 // Version for Windows 10 1809 to 22H2
 // Compile with:
 // C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe VirtualDesktop.cs
@@ -17,11 +17,11 @@ using System.Reflection;
 [assembly:AssemblyConfiguration("")]
 [assembly:AssemblyCompany("MS")]
 [assembly:AssemblyProduct("VirtualDesktop")]
-[assembly:AssemblyCopyright("© Markus Scholtes 2024")]
+[assembly:AssemblyCopyright("\u00A9 Markus Scholtes, Duncan Lilly - 2025")]
 [assembly:AssemblyTrademark("")]
 [assembly:AssemblyCulture("")]
-[assembly:AssemblyVersion("1.19.0.0")]
-[assembly:AssemblyFileVersion("1.19.0.0")]
+[assembly:AssemblyVersion("1.20.0.0")]
+[assembly:AssemblyFileVersion("1.20.0.0")]
 
 // Based on http://stackoverflow.com/a/32417530, Windows 10 SDK, github project Grabacr07/VirtualDesktop and own research
 
@@ -692,7 +692,6 @@ namespace VDeskTool
 {
 	static class Program
 	{
-
 		static bool verbose = true;
 		static bool breakonerror = true;
 		static bool wrapdesktops = false;
@@ -704,6 +703,60 @@ namespace VDeskTool
 			{ // no arguments, show help screen
 				HelpScreen();
 				return -2;
+			}
+
+			// Pre parse any settings that should apply globally (i.e a setting like
+			// VERBOSE should apply no matter where in the command line order it appears)
+			foreach (string arg in args)
+			{
+				System.Text.RegularExpressions.GroupCollection groups = System.Text.RegularExpressions.Regex.Match(arg, @"^[-\/]?([^:=]+)[:=]?(.*)$").Groups;
+
+				if (groups[2].Value == "")
+				{ // parameter without value
+					switch(groups[1].Value.ToUpper())
+					{
+						case "HELP": // help screen
+						case "H":
+						case "?":
+							HelpScreen();
+							return 0;
+
+						case "QUIET": // don't display messages
+						case "Q":
+							verbose = false;
+							break;
+
+						case "VERBOSE": // display messages
+						case "V":
+							Console.WriteLine("Verbose mode enabled");
+							verbose = true;
+							break;
+
+						case "BREAK": // break on error
+						case "B":
+							if (verbose) Console.WriteLine("Break on error enabled");
+							breakonerror = true;
+							break;
+
+						case "CONTINUE": // continue on error
+						case "CO":
+							if (verbose) Console.WriteLine("Break on error disabled");
+							breakonerror = false;
+							break;
+
+						case "WRAP": // wrap desktops using "LEFT" or "RIGHT"
+						case "W":
+							if (verbose) Console.WriteLine("Wrapping desktops enabled");
+							wrapdesktops = true;
+							break;
+
+						case "NOWRAP": // do not wrap desktops
+						case "NW":
+							if (verbose) Console.WriteLine("Wrapping desktop disabled");
+							wrapdesktops = false;
+							break;
+					}
+				}
 			}
 
 			foreach (string arg in args)
@@ -722,45 +775,19 @@ namespace VDeskTool
 					{ // parameter without value
 						switch(groups[1].Value.ToUpper())
 						{
-							case "HELP": // help screen
-							case "H":
-							case "?":
-								HelpScreen();
-								return 0;
-
+							// All these are handled earlier; so supress any error by doing nothing
 							case "QUIET": // don't display messages
 							case "Q":
-								verbose = false;
-								break;
-
 							case "VERBOSE": // display messages
 							case "V":
-								Console.WriteLine("Verbose mode enabled");
-								verbose = true;
-								break;
-
 							case "BREAK": // break on error
 							case "B":
-								if (verbose) Console.WriteLine("Break on error enabled");
-								breakonerror = true;
-								break;
-
 							case "CONTINUE": // continue on error
 							case "CO":
-								if (verbose) Console.WriteLine("Break on error disabled");
-								breakonerror = false;
-								break;
-
 							case "WRAP": // wrap desktops using "LEFT" or "RIGHT"
 							case "W":
-								if (verbose) Console.WriteLine("Wrapping desktops enabled");
-								wrapdesktops = true;
-								break;
-
 							case "NOWRAP": // do not wrap desktops
 							case "NW":
-								if (verbose) Console.WriteLine("Wrapping desktop disabled");
-								wrapdesktops = false;
 								break;
 
 							case "COUNT": // get count of desktops
@@ -2522,7 +2549,7 @@ namespace VDeskTool
 
 		static void HelpScreen()
 		{
-			Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2024, v1.19\n");
+			Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes & Duncan Lilly, 2025, v1.20\n");
 
 			Console.WriteLine("Command line tool to manage the virtual desktops of Windows 10.");
 			Console.WriteLine("Parameters can be given as a sequence of commands. The result - most of the");

--- a/VirtualDesktop11-24H2.cs
+++ b/VirtualDesktop11-24H2.cs
@@ -1,5 +1,5 @@
-// Author: Markus Scholtes, 2024
-// Version 1.19, 2024-09-01
+// Author: Markus Scholtes, Duncan Lilly - 2024-2025
+// Version 1.20 2025-01-18
 // Version for Windows 11 24H2 Insider
 // Compile with:
 // C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe VirtualDesktop11-24H2.cs
@@ -17,11 +17,11 @@ using System.Reflection;
 [assembly:AssemblyConfiguration("")]
 [assembly:AssemblyCompany("MS")]
 [assembly:AssemblyProduct("VirtualDesktop")]
-[assembly:AssemblyCopyright("\u00A9 Markus Scholtes 2024")]
+[assembly:AssemblyCopyright("\u00A9 Markus Scholtes, Duncan Lilly - 2025")]
 [assembly:AssemblyTrademark("")]
 [assembly:AssemblyCulture("")]
-[assembly:AssemblyVersion("1.19.0.0")]
-[assembly:AssemblyFileVersion("1.19.0.0")]
+[assembly:AssemblyVersion("1.20.0.0")]
+[assembly:AssemblyFileVersion("1.20.0.0")]
 
 // Based on http://stackoverflow.com/a/32417530, Windows 10 SDK, github project Grabacr07/VirtualDesktop and own research
 
@@ -705,6 +705,72 @@ namespace VDeskTool
 				return -2;
 			}
 
+			// Pre parse any settings that should apply globally (i.e a setting like
+			// VERBOSE should apply no matter where in the command line order it appears)
+			foreach (string arg in args)
+			{
+				System.Text.RegularExpressions.GroupCollection groups = System.Text.RegularExpressions.Regex.Match(arg, @"^[-\/]?([^:=]+)[:=]?(.*)$").Groups;
+
+				if (groups[2].Value == "")
+				{ // parameter without value
+					switch(groups[1].Value.ToUpper())
+					{
+						case "HELP": // help screen
+						case "H":
+						case "?":
+							HelpScreen();
+							return 0;
+
+						case "QUIET": // don't display messages
+						case "Q":
+							verbose = false;
+							break;
+
+						case "VERBOSE": // display messages
+						case "V":
+							Console.WriteLine("Verbose mode enabled");
+							verbose = true;
+							break;
+
+						case "ANIMATE": // Use animation
+						case "A":
+							if (verbose) Console.WriteLine("Animation enabled");
+							animate = true;
+							break;
+
+						case "INSTANT": // Flip instantly
+						case "I":
+							if (verbose) Console.WriteLine("Animation disabled");
+							animate = false;
+							break;
+
+						case "BREAK": // break on error
+						case "B":
+							if (verbose) Console.WriteLine("Break on error enabled");
+							breakonerror = true;
+							break;
+
+						case "CONTINUE": // continue on error
+						case "CO":
+							if (verbose) Console.WriteLine("Break on error disabled");
+							breakonerror = false;
+							break;
+
+						case "WRAP": // wrap desktops using "LEFT" or "RIGHT"
+						case "W":
+							if (verbose) Console.WriteLine("Wrapping desktops enabled");
+							wrapdesktops = true;
+							break;
+
+						case "NOWRAP": // do not wrap desktops
+						case "NW":
+							if (verbose) Console.WriteLine("Wrapping desktop disabled");
+							wrapdesktops = false;
+							break;
+					}
+				}
+			}
+
 			foreach (string arg in args)
 			{
 				System.Text.RegularExpressions.GroupCollection groups = System.Text.RegularExpressions.Regex.Match(arg, @"^[-\/]?([^:=]+)[:=]?(.*)$").Groups;
@@ -721,57 +787,23 @@ namespace VDeskTool
 					{ // parameter without value
 						switch(groups[1].Value.ToUpper())
 						{
-							case "HELP": // help screen
-							case "H":
-							case "?":
-								HelpScreen();
-								return 0;
-
+							// All these are handled earlier; so supress any error by doing nothing
 							case "QUIET": // don't display messages
 							case "Q":
-								verbose = false;
-								break;
-
 							case "VERBOSE": // display messages
 							case "V":
-								Console.WriteLine("Verbose mode enabled");
-								verbose = true;
-								break;
-
 							case "ANIMATE": // Use animation
 							case "A":
-								Console.WriteLine("Animation enabled");
-								animate = true;
-								break;
-
 							case "INSTANT": // Flip instantly
 							case "I":
-								Console.WriteLine("Animation disabled");
-								animate = false;
-								break;
-
 							case "BREAK": // break on error
 							case "B":
-								if (verbose) Console.WriteLine("Break on error enabled");
-								breakonerror = true;
-								break;
-
 							case "CONTINUE": // continue on error
 							case "CO":
-								if (verbose) Console.WriteLine("Break on error disabled");
-								breakonerror = false;
-								break;
-
 							case "WRAP": // wrap desktops using "LEFT" or "RIGHT"
 							case "W":
-								if (verbose) Console.WriteLine("Wrapping desktops enabled");
-								wrapdesktops = true;
-								break;
-
 							case "NOWRAP": // do not wrap desktops
 							case "NW":
-								if (verbose) Console.WriteLine("Wrapping desktop disabled");
-								wrapdesktops = false;
 								break;
 
 							case "COUNT": // get count of desktops
@@ -2508,7 +2540,7 @@ namespace VDeskTool
 
 		static void HelpScreen()
 		{
-			Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2024, v1.19\n");
+			Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes & Duncan Lilly, 2025, v1.20\n");
 
 			Console.WriteLine("Command line tool to manage the virtual desktops of Windows 11.");
 			Console.WriteLine("Parameters can be given as a sequence of commands. The result - most of the");

--- a/VirtualDesktop11.cs
+++ b/VirtualDesktop11.cs
@@ -1,5 +1,5 @@
-// Author: Markus Scholtes, 2024
-// Version 1.19, 2024-09-01
+// Author: Markus Scholtes, Duncan Lilly - 2024-2025
+// Version 1.20 2025-01-18
 // Version for Windows 11
 // Compile with:
 // C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe VirtualDesktop11.cs
@@ -17,11 +17,11 @@ using System.Reflection;
 [assembly:AssemblyConfiguration("")]
 [assembly:AssemblyCompany("MS")]
 [assembly:AssemblyProduct("VirtualDesktop")]
-[assembly:AssemblyCopyright("\u00A9 Markus Scholtes 2024")]
+[assembly:AssemblyCopyright("\u00A9 Markus Scholtes, Duncan Lilly - 2025")]
 [assembly:AssemblyTrademark("")]
 [assembly:AssemblyCulture("")]
-[assembly:AssemblyVersion("1.19.0.0")]
-[assembly:AssemblyFileVersion("1.19.0.0")]
+[assembly:AssemblyVersion("1.20.0.0")]
+[assembly:AssemblyFileVersion("1.20.0.0")]
 
 // Based on http://stackoverflow.com/a/32417530, Windows 10 SDK, github project Grabacr07/VirtualDesktop and own research
 
@@ -704,6 +704,72 @@ namespace VDeskTool
 				return -2;
 			}
 
+			// Pre parse any settings that should apply globally (i.e a setting like
+			// VERBOSE should apply no matter where in the command line order it appears)
+			foreach (string arg in args)
+			{
+				System.Text.RegularExpressions.GroupCollection groups = System.Text.RegularExpressions.Regex.Match(arg, @"^[-\/]?([^:=]+)[:=]?(.*)$").Groups;
+
+				if (groups[2].Value == "")
+				{ // parameter without value
+					switch(groups[1].Value.ToUpper())
+					{
+						case "HELP": // help screen
+						case "H":
+						case "?":
+							HelpScreen();
+							return 0;
+
+						case "QUIET": // don't display messages
+						case "Q":
+							verbose = false;
+							break;
+
+						case "VERBOSE": // display messages
+						case "V":
+							Console.WriteLine("Verbose mode enabled");
+							verbose = true;
+							break;
+
+						case "ANIMATE": // Use animation
+						case "A":
+							if (verbose) Console.WriteLine("Animation enabled");
+							animate = true;
+							break;
+
+						case "INSTANT": // Flip instantly
+						case "I":
+							if (verbose) Console.WriteLine("Animation disabled");
+							animate = false;
+							break;
+
+						case "BREAK": // break on error
+						case "B":
+							if (verbose) Console.WriteLine("Break on error enabled");
+							breakonerror = true;
+							break;
+
+						case "CONTINUE": // continue on error
+						case "CO":
+							if (verbose) Console.WriteLine("Break on error disabled");
+							breakonerror = false;
+							break;
+
+						case "WRAP": // wrap desktops using "LEFT" or "RIGHT"
+						case "W":
+							if (verbose) Console.WriteLine("Wrapping desktops enabled");
+							wrapdesktops = true;
+							break;
+
+						case "NOWRAP": // do not wrap desktops
+						case "NW":
+							if (verbose) Console.WriteLine("Wrapping desktop disabled");
+							wrapdesktops = false;
+							break;
+					}
+				}
+			}
+
 			foreach (string arg in args)
 			{
 				System.Text.RegularExpressions.GroupCollection groups = System.Text.RegularExpressions.Regex.Match(arg, @"^[-\/]?([^:=]+)[:=]?(.*)$").Groups;
@@ -720,57 +786,23 @@ namespace VDeskTool
 					{ // parameter without value
 						switch(groups[1].Value.ToUpper())
 						{
-							case "HELP": // help screen
-							case "H":
-							case "?":
-								HelpScreen();
-								return 0;
-
+							// All these are handled earlier; so supress any error by doing nothing
 							case "QUIET": // don't display messages
 							case "Q":
-								verbose = false;
-								break;
-
 							case "VERBOSE": // display messages
 							case "V":
-								Console.WriteLine("Verbose mode enabled");
-								verbose = true;
-								break;
-
 							case "ANIMATE": // Use animation
 							case "A":
-								Console.WriteLine("Animation enabled");
-								animate = true;
-								break;
-
 							case "INSTANT": // Flip instantly
 							case "I":
-								Console.WriteLine("Animation disabled");
-								animate = false;
-								break;
-
 							case "BREAK": // break on error
 							case "B":
-								if (verbose) Console.WriteLine("Break on error enabled");
-								breakonerror = true;
-								break;
-
 							case "CONTINUE": // continue on error
 							case "CO":
-								if (verbose) Console.WriteLine("Break on error disabled");
-								breakonerror = false;
-								break;
-
 							case "WRAP": // wrap desktops using "LEFT" or "RIGHT"
 							case "W":
-								if (verbose) Console.WriteLine("Wrapping desktops enabled");
-								wrapdesktops = true;
-								break;
-
 							case "NOWRAP": // do not wrap desktops
 							case "NW":
-								if (verbose) Console.WriteLine("Wrapping desktop disabled");
-								wrapdesktops = false;
 								break;
 
 							case "COUNT": // get count of desktops
@@ -2507,7 +2539,7 @@ namespace VDeskTool
 
 		static void HelpScreen()
 		{
-			Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2024, v1.19\n");
+			Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes & Duncan Lilly, 2025, v1.20\n");
 
 			Console.WriteLine("Command line tool to manage the virtual desktops of Windows 11.");
 			Console.WriteLine("Parameters can be given as a sequence of commands. The result - most of the");

--- a/VirtualDesktopServer2016.cs
+++ b/VirtualDesktopServer2016.cs
@@ -1,5 +1,5 @@
-// Author: Markus Scholtes, 2024
-// Version 1.19, 2024-09-01
+// Author: Markus Scholtes, Duncan Lilly - 2024-2025
+// Version 1.20 2025-01-18
 // Version for Windows 10 1607 to 1709 or Windows Server 2016
 // Compile with:
 // C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe VirtualDesktop1607.cs
@@ -17,11 +17,11 @@ using System.Reflection;
 [assembly:AssemblyConfiguration("")]
 [assembly:AssemblyCompany("MS")]
 [assembly:AssemblyProduct("VirtualDesktop")]
-[assembly:AssemblyCopyright("© Markus Scholtes 2024")]
+[assembly:AssemblyCopyright("\u00A9 Markus Scholtes, Duncan Lilly - 2025")]
 [assembly:AssemblyTrademark("")]
 [assembly:AssemblyCulture("")]
-[assembly:AssemblyVersion("1.19.0.0")]
-[assembly:AssemblyFileVersion("1.19.0.0")]
+[assembly:AssemblyVersion("1.20.0.0")]
+[assembly:AssemblyFileVersion("1.20.0.0")]
 
 // Based on http://stackoverflow.com/a/32417530, Windows 10 SDK, github project Grabacr07/VirtualDesktop and own research
 
@@ -624,6 +624,60 @@ namespace VDeskTool
 				return -2;
 			}
 
+			// Pre parse any settings that should apply globally (i.e a setting like
+			// VERBOSE should apply no matter where in the command line order it appears)
+			foreach (string arg in args)
+			{
+				System.Text.RegularExpressions.GroupCollection groups = System.Text.RegularExpressions.Regex.Match(arg, @"^[-\/]?([^:=]+)[:=]?(.*)$").Groups;
+
+				if (groups[2].Value == "")
+				{ // parameter without value
+					switch(groups[1].Value.ToUpper())
+					{
+						case "HELP": // help screen
+						case "H":
+						case "?":
+							HelpScreen();
+							return 0;
+
+						case "QUIET": // don't display messages
+						case "Q":
+							verbose = false;
+							break;
+
+						case "VERBOSE": // display messages
+						case "V":
+							Console.WriteLine("Verbose mode enabled");
+							verbose = true;
+							break;
+
+						case "BREAK": // break on error
+						case "B":
+							if (verbose) Console.WriteLine("Break on error enabled");
+							breakonerror = true;
+							break;
+
+						case "CONTINUE": // continue on error
+						case "CO":
+							if (verbose) Console.WriteLine("Break on error disabled");
+							breakonerror = false;
+							break;
+
+						case "WRAP": // wrap desktops using "LEFT" or "RIGHT"
+						case "W":
+							if (verbose) Console.WriteLine("Wrapping desktops enabled");
+							wrapdesktops = true;
+							break;
+
+						case "NOWRAP": // do not wrap desktops
+						case "NW":
+							if (verbose) Console.WriteLine("Wrapping desktop disabled");
+							wrapdesktops = false;
+							break;
+					}
+				}
+			}
+
 			foreach (string arg in args)
 			{
 				System.Text.RegularExpressions.GroupCollection groups = System.Text.RegularExpressions.Regex.Match(arg, @"^[-\/]?([^:=]+)[:=]?(.*)$").Groups;
@@ -640,45 +694,19 @@ namespace VDeskTool
 					{ // parameter without value
 						switch(groups[1].Value.ToUpper())
 						{
-							case "HELP": // help screen
-							case "H":
-							case "?":
-								HelpScreen();
-								return 0;
-
+							// All these are handled earlier; so supress any error by doing nothing
 							case "QUIET": // don't display messages
 							case "Q":
-								verbose = false;
-								break;
-
 							case "VERBOSE": // display messages
 							case "V":
-								Console.WriteLine("Verbose mode enabled");
-								verbose = true;
-								break;
-
 							case "BREAK": // break on error
 							case "B":
-								if (verbose) Console.WriteLine("Break on error enabled");
-								breakonerror = true;
-								break;
-
 							case "CONTINUE": // continue on error
 							case "CO":
-								if (verbose) Console.WriteLine("Break on error disabled");
-								breakonerror = false;
-								break;
-
 							case "WRAP": // wrap desktops using "LEFT" or "RIGHT"
 							case "W":
-								if (verbose) Console.WriteLine("Wrapping desktops enabled");
-								wrapdesktops = true;
-								break;
-
 							case "NOWRAP": // do not wrap desktops
 							case "NW":
-								if (verbose) Console.WriteLine("Wrapping desktop disabled");
-								wrapdesktops = false;
 								break;
 
 							case "COUNT": // get count of desktops
@@ -2387,7 +2415,7 @@ namespace VDeskTool
 
 		static void HelpScreen()
 		{
-			Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2024, v1.19\n");
+			Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes & Duncan Lilly, 2025, v1.20\n");
 
 			Console.WriteLine("Command line tool to manage the virtual desktops of Windows Server 2016.");
 			Console.WriteLine("Parameters can be given as a sequence of commands. The result - most of the");

--- a/VirtualDesktopServer2022.cs
+++ b/VirtualDesktopServer2022.cs
@@ -1,5 +1,5 @@
-// Author: Markus Scholtes, 2024
-// Version 1.19, 2024-09-01
+// Author: Markus Scholtes, Duncan Lilly - 2024-2025
+// Version 1.20 2025-01-18
 // Version for Windows Server 2022
 // Compile with:
 // C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe VirtualDesktop.cs
@@ -17,11 +17,11 @@ using System.Reflection;
 [assembly:AssemblyConfiguration("")]
 [assembly:AssemblyCompany("MS")]
 [assembly:AssemblyProduct("VirtualDesktop")]
-[assembly:AssemblyCopyright("© Markus Scholtes 2024")]
+[assembly:AssemblyCopyright("\u00A9 Markus Scholtes, Duncan Lilly - 2025")]
 [assembly:AssemblyTrademark("")]
 [assembly:AssemblyCulture("")]
-[assembly:AssemblyVersion("1.19.0.0")]
-[assembly:AssemblyFileVersion("1.19.0.0")]
+[assembly:AssemblyVersion("1.20.0.0")]
+[assembly:AssemblyFileVersion("1.20.0.0")]
 
 // Based on http://stackoverflow.com/a/32417530, Windows 10 SDK, github project Grabacr07/VirtualDesktop and own research
 
@@ -682,6 +682,60 @@ namespace VDeskTool
 				return -2;
 			}
 
+			// Pre parse any settings that should apply globally (i.e a setting like
+			// VERBOSE should apply no matter where in the command line order it appears)
+			foreach (string arg in args)
+			{
+				System.Text.RegularExpressions.GroupCollection groups = System.Text.RegularExpressions.Regex.Match(arg, @"^[-\/]?([^:=]+)[:=]?(.*)$").Groups;
+
+				if (groups[2].Value == "")
+				{ // parameter without value
+					switch(groups[1].Value.ToUpper())
+					{
+						case "HELP": // help screen
+						case "H":
+						case "?":
+							HelpScreen();
+							return 0;
+
+						case "QUIET": // don't display messages
+						case "Q":
+							verbose = false;
+							break;
+
+						case "VERBOSE": // display messages
+						case "V":
+							Console.WriteLine("Verbose mode enabled");
+							verbose = true;
+							break;
+
+						case "BREAK": // break on error
+						case "B":
+							if (verbose) Console.WriteLine("Break on error enabled");
+							breakonerror = true;
+							break;
+
+						case "CONTINUE": // continue on error
+						case "CO":
+							if (verbose) Console.WriteLine("Break on error disabled");
+							breakonerror = false;
+							break;
+
+						case "WRAP": // wrap desktops using "LEFT" or "RIGHT"
+						case "W":
+							if (verbose) Console.WriteLine("Wrapping desktops enabled");
+							wrapdesktops = true;
+							break;
+
+						case "NOWRAP": // do not wrap desktops
+						case "NW":
+							if (verbose) Console.WriteLine("Wrapping desktop disabled");
+							wrapdesktops = false;
+							break;
+					}
+				}
+			}
+
 			foreach (string arg in args)
 			{
 				System.Text.RegularExpressions.GroupCollection groups = System.Text.RegularExpressions.Regex.Match(arg, @"^[-\/]?([^:=]+)[:=]?(.*)$").Groups;
@@ -698,45 +752,19 @@ namespace VDeskTool
 					{ // parameter without value
 						switch(groups[1].Value.ToUpper())
 						{
-							case "HELP": // help screen
-							case "H":
-							case "?":
-								HelpScreen();
-								return 0;
-
+							// All these are handled earlier; so supress any error by doing nothing
 							case "QUIET": // don't display messages
 							case "Q":
-								verbose = false;
-								break;
-
 							case "VERBOSE": // display messages
 							case "V":
-								Console.WriteLine("Verbose mode enabled");
-								verbose = true;
-								break;
-
 							case "BREAK": // break on error
 							case "B":
-								if (verbose) Console.WriteLine("Break on error enabled");
-								breakonerror = true;
-								break;
-
 							case "CONTINUE": // continue on error
 							case "CO":
-								if (verbose) Console.WriteLine("Break on error disabled");
-								breakonerror = false;
-								break;
-
 							case "WRAP": // wrap desktops using "LEFT" or "RIGHT"
 							case "W":
-								if (verbose) Console.WriteLine("Wrapping desktops enabled");
-								wrapdesktops = true;
-								break;
-
 							case "NOWRAP": // do not wrap desktops
 							case "NW":
-								if (verbose) Console.WriteLine("Wrapping desktop disabled");
-								wrapdesktops = false;
 								break;
 
 							case "COUNT": // get count of desktops
@@ -2498,9 +2526,9 @@ namespace VDeskTool
 
 		static void HelpScreen()
 		{
-			Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2024, v1.19\n");
+			Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes & Duncan Lilly, 2025, v1.20\n");
 
-			Console.WriteLine("Command line tool to manage the virtual desktops of Windows Server 2022.");
+			Console.WriteLine("Command line tool to manage the virtual desktops of Windows Server 2016.");
 			Console.WriteLine("Parameters can be given as a sequence of commands. The result - most of the");
 			Console.WriteLine("times the number of the processed desktop - can be used as input for the next");
 			Console.WriteLine("parameter. The result of the last command is returned as error level.");


### PR DESCRIPTION
Options that set global flags get parsed first - so setting the /INSTANT option anywhere applies to all,  rather than just ignoring it if you were to pass it as the last parameter.

This probably goes against the original author's "pipeline" idea;  but makes more sense to me!  everything else will work as before - just the setting options are now global.